### PR TITLE
mount-namespaces: Fix extra backticks

### DIFF
--- a/_posts/2023-02-28-mounting-into-mount-namespaces.md
+++ b/_posts/2023-02-28-mounting-into-mount-namespaces.md
@@ -232,7 +232,6 @@ The main point is that before `move_mount()` is called a detached mount doesn't 
 To mount a filesystem into a new mount namespace we can make use of the split between configuring a filesystem context and creating a new superblock and actually attaching the mount to the filesystem hiearchy:
 
 ```c
-```
 fd_fs = fsopen("xfs");
 fsconfig(fd_fs, FSCONFIG_SET_STRING, "source", "/dev/sda", 0);
 fsconfig(fd_fs, FSCONFIG_CMD_CREATE, NULL, NULL, 0);


### PR DESCRIPTION
This was breaking rendering.